### PR TITLE
Translate install-cockroachdb-linux.html v19.1/ko

### DIFF
--- a/l10n/ko/GLOSSARY.md
+++ b/l10n/ko/GLOSSARY.md
@@ -1,0 +1,20 @@
+| English | 한글 | 비고 |
+| ------- | --- | --- |
+| application | 애플리케이션 | |
+| archive | 아카이브 | |
+| best practices | 모범사례 | |
+| cluster | 클러스터 | |
+| CockroachDB | 칵로치디비 | |
+| core | 코어 | 칵로치디비 오픈소스 코어를 말하는 경우 |
+| daemon | 데몬 | 서버 프로세스를 말하는 경우 |
+| Docker | 도커 | |
+| Docker Hub | 도커 허브 | |
+| Kubernetes | 쿠버네티스 | |
+| release | 릴리즈 | |
+| stateful | 스테이트풀 | 상태를 저장한다는 의미인 경우 |
+| Helm | 헬름 | [https://helm.sh/](https://helm.sh/)을 말하는 경우 |
+| macOS | 맥OS | |
+| Minikube | 미니쿠베 | |
+| local | 로컬 | 개발자 로컬 장비를 의미하는 경우 |
+| package manager | 패키지 매니저 | |
+| What's next? | 무엇을 더 알아볼까요? | 문서에서 다음에 더 찾아볼 문서을 안내할 경우 |

--- a/v19.1/ko/install-cockroachdb-linux.html
+++ b/v19.1/ko/install-cockroachdb-linux.html
@@ -1,5 +1,5 @@
 ---
-title: Install CockroachDB on Linux
+title: 리눅스에 칵로치디비 설치
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 tags: download, binary, homebrew
 toc: true
@@ -12,16 +12,16 @@ key: install-cockroachdb.html
   <a href="install-cockroachdb-windows.html"><button id="windows" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button></a>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
+<p>마지막 릴리즈, {{ page.release_info.version }} 에 추가된 내용을 알고 싶으면 <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">릴리즈 노트</a>를 보십시오. 오래된 버전에서 이 릴리즈로 업그레이드하려면 <a href="upgrade-cockroach-version.html">클러스터 업그레이드</a>를 보십시오.</p>
 
 <div id="download-the-binary-linux" class="install-option">
-  <h2>Download the Binary</h2>
+  <h2>실행파일 다운로드</h2>
 
   {% include {{ page.version.version }}/misc/linux-binary-prereqs.md %}
 
   <ol>
     <li>
-      <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz"  data-eventcategory="linux-binary-step1">CockroachDB archive</a> for Linux, and extract the binary:</p>
+      <p>리눅스 <a href="https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz"  data-eventcategory="linux-binary-step1">칵로치디비 아카이브</a>를 다운로드받고, 압축을 푸십시오:</p>
 
       <div class="copy-clipboard">
         <div class="copy-clipboard__text linux-binary-step1-button" id="linux-binary-step1-button-{{ page.version.version }}" data-eventcategory="linux-binary-step1-button">copy</div>
@@ -31,13 +31,13 @@ key: install-cockroachdb.html
       <div class="highlight"><pre class="highlight"><code data-eventcategory="linux-binary-step1"><span class="gp linux-binary-step1" id="linux-binary-step1-{{ page.version.version }}" data-eventcategory="linux-binary-step1">$ </span>wget -qO- https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz | tar  xvz</code></pre></div>
     </li>
     <li>
-      <p>Copy the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
+      <p>실행파일을 당신의 <code>PATH</code>에 복사하여 <a href="cockroach-commands.html">칵로치 명령어</a>를 아무 쉘에서나 사용할 수 있게 하십시오:</p>
 
       {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin</code></pre></div>
-      <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
+      <p>권한 에러가 나오면 <code>sudo</code>를 이용해 명령어를 사용하십시오.</p>
     </li>
     <li>
-      <p>Keep up-to-date with CockroachDB releases and best practices:</p>
+      <p>칵로치 디비 릴리즈와 모범사례를 최신으로 유지하십시오:</p>
       <div class="hubspot-install-form install-form-5 clearfix">
         <script>
           hbspt.forms.create({
@@ -55,28 +55,28 @@ key: install-cockroachdb.html
 </div>
 
 <div id="use-kubernetes" class="install-option">
-  <h2>Use Kubernetes</h2>
+  <h2>쿠버네티스 사용하기</h2>
 
-  <p>To orchestrate CockroachDB using <a href="https://kubernetes.io/">Kubernetes</a>, either with configuration files or the <a href="https://helm.sh/">Helm</a> package manager, use the following tutorials:</p>
+  <p>설정 파일 또는 <a href="https://helm.sh/">헬름</a> 패키지 매니저를 통해 <a href="https://kubernetes.io/">쿠버네티스</a>로 칵로치디비를 오케스트레이션하려면, 아래 튜토리얼을 사용하십시오:</p>
 
   <ul>
-  <li><a href="orchestrate-a-local-cluster-with-kubernetes.html">Orchestrate CockroachDB Locally with Minikube</a></li>
-  <li><a href="orchestrate-cockroachdb-with-kubernetes.html">Orchestrate CockroachDB in a Single Kubernetes Cluster</a></li>
-  <li><a href="orchestrate-cockroachdb-with-kubernetes-multi-cluster.html">Orchestrate CockroachDB Across Multiple Kubernetes Clusters</a></li>
+  <li><a href="orchestrate-a-local-cluster-with-kubernetes.html">미니쿠베를 이용한 칵로치디비 로컬 오케스트레이션</a></li>
+  <li><a href="orchestrate-cockroachdb-with-kubernetes.html">단일 쿠버네티스 클러스트를 이용한 칵로치디비 오케스트레이션</a></li>
+  <li><a href="orchestrate-cockroachdb-with-kubernetes-multi-cluster.html">멀티 쿠버네티스 클러스터를 가로지르는 칵로치디비 오케스트레이션</a></li>
   </ul>
 </div>
 
 <div id="use-docker-linux" class="install-option">
-  <h2>Use Docker</h2>
+  <h2>도커 사용하기</h2>
 
-  {{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+  {{site.data.alerts.callout_danger}} 칵로치디비와 같은 스테이트풀 애플리케이션을 도커에서 사용하는 것은 일반적인 도커 사용보다 더 복잡하고 오류가 발생하기 쉽습니다. 도커에 매우 숙련되어 있지 않다면, 다른 설치 및 배포 방법으로 시작하시는 것을 권고드립니다.{{site.data.alerts.end}}
 
   <ol>
     <li>
-      <p>Install <a href="https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/">Docker for Linux</a>. Please carefully check that you meet all prerequisites.</p>
+      <p>리눅스에 <a href="https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/">도커를 설치한다</a>. 모든 전제조건을 충족했는지 확인해 주십시오.</p>
     </li>
     <li>
-      <p>Confirm that the Docker daemon is running in the background:</p>
+      <p>도커 데몬이 백그라운드에서 동작하는지 확인하십시오:</p>
 
       <div class="copy-clipboard">
         <div class="copy-clipboard__text linux-docker-button" id="linux-docker-button-{{ page.version.version }}" data-eventcategory="linux-docker-button">copy</div>
@@ -84,12 +84,12 @@ key: install-cockroachdb.html
         <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
       </div>
       <div class="highlight"><pre class="highlight"><code data-eventcategory="linux-docker-step2"><span class="gp linux-docker-step2" id="linux-docker-step2-{{ page.version.version }}" data-eventcategory="linux-docker-step2">$ </span>docker version</code></pre></div>
-      <p>If you do not see the server listed, start the <strong>Docker</strong> daemon.</p>
+      <p>서버 목록이 보이지 않으면, <strong>Docker</strong> 데몬을 시작하십시오.</p>
 
-      {{site.data.alerts.callout_info}}On Linux, Docker needs sudo privileges.{{site.data.alerts.end}}
+      {{site.data.alerts.callout_info}}리눅스에서, 도커는 sudo 권한을 요구합니다.{{site.data.alerts.end}}
     </li>
     <li>
-      <p>Pull the image for the {{page.release_info.version}} release of CockroachDB from <a href="https://hub.docker.com/r/{{page.release_info.docker_image}}/" class="linux-docker-step3" id="linux-docker-step3-{{page.version.version}}" data-eventcategory="linux-docker-step3">Docker Hub</a>:</p>
+      <p>칵로치디비 {{page.release_info.version}} 릴리즈를 <a href="https://hub.docker.com/r/{{page.release_info.docker_image}}/" class="linux-docker-step3" id="linux-docker-step3-{{page.version.version}}" data-eventcategory="linux-docker-step3">도커 허브에서 다운로드받으십시오</a>:</p>
 
       <div class="copy-clipboard">
         <div class="copy-clipboard__text linux-docker-button" id="linux-docker-button-{{ page.version.version }}" data-eventcategory="linux-docker-button">copy</div>
@@ -100,7 +100,7 @@ key: install-cockroachdb.html
       </div>
     </li>
     <li>
-      <p>Keep up-to-date with CockroachDB releases and best practices:</p>
+      <p>칵로치 디비 릴리즈와 모범사례를 최신으로 유지하십시오:</p>
       <div class="hubspot-install-form install-form-7 clearfix">
         <script>
           hbspt.forms.create({
@@ -118,37 +118,37 @@ key: install-cockroachdb.html
 </div>
 
 <div id="build-from-source-linux" class="install-option">
-  <h2>Build from Source</h2>
+  <h2>소스에서 빌드하기</h2>
   <ol>
     <li>
-      <p>Install the following prerequisites, as necessary:</p>
+      <p>다음 요구사항을 설치하십시오:</p>
 
       <table>
         <tr>
-          <td>C++ compiler</td>
-          <td>Must support C++ 11. GCC prior to 6.0 does not work due to <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891">this issue</a>. On macOS, Xcode should suffice.</td>
+          <td>C++ 컴파일러</td>
+          <td>C++ 11을 지원해야 합니다. 6.0 이전의 GCC는 <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891">이 이슈</a> 때문에 동작하지 않습니다. 맥OS에서는 Xcode로 충분합니다.</td>
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.11.6 or higher is required.</td>
+          <td>버전 1.11.6 이상이 필요합니다.</td>
         </tr>
         <tr>
           <td>Bash</td>
-          <td>Versions 4+ are preferred, but later releases from the 3.x series are also known to work.</td>
+          <td>버전 4 이상이 선호되지만, 3.x 이후 릴리즈도 동작하는 것으로 알려져 있습니다.</td>
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>버전 3.81 이상이 동작하는 것으로 알려져 있습니다.</td>
         </tr>
         <tr>
           <td>Autoconf</td>
-          <td>Version 2.68 or higher is required.</td>
+          <td>버전 2.68 이상이 필요합니다.</td>
         </tr>
       </table>
-      <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>
+      <p>64비트 시스템을 강력히 권장합니다. 32비트 시스템에서 칵로치디비를 빌드 또는 실행하는 것은 테스트되지 않았습니다. 또 2GB 이상의 RAM이 필요합니다. 테스트를 실행하려면 4GB에 가까운 RAM이 필요합니다.</p>
     </li>
     <li>
-      <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.src.tgz" class="linux-source-download" id="linux-source-download-{{page.version.version}}" data-eventcategory="linux-source-download">CockroachDB {{ page.release_info.version }} source archive</a>, and extract the sources:</p>
+      <p><a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.src.tgz" class="linux-source-download" id="linux-source-download-{{page.version.version}}" data-eventcategory="linux-source-download">칵로치디비 {{ page.release_info.version }} 소스 아카이브</a>를 다운로드 받고, 압축을 푸십시오:</p>
 
       <div class="copy-clipboard">
         <div class="copy-clipboard__text linux-source-button" id="linux-source-button-{{ page.version.version }}" data-eventcategory="linux-source-button">copy</div>
@@ -157,27 +157,27 @@ key: install-cockroachdb.html
       </div>
       <div class="highlight"><pre class="highlight"><code data-eventcategory="linux-source-step1"><span class="gp linux-source-step1" id="linux-source-step1-{{ page.version.version }}" data-eventcategory="linux-source-step1">$ </span>wget -qO- https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.src.tgz | tar  xvz</code></pre></div>
     </li>
-    <li><p>In the extracted directory, run <code>make build</code>:</p>
+    <li><p>압축이 풀린 디렉토리에서, <code>make build</code>를 실행하십시오:</p>
 
       {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-{{ page.release_info.version }}</code></pre></div>
 
       {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>make build</code></pre></div>
 
-      <p>The build process can take 10+ minutes, so please be patient.</p>
+      <p>빌드 프로세스에 10분 이상이 소요되니, 잠시 기다려 주십시오.</p>
 
-      {{site.data.alerts.callout_info}}The default binary contains core open-source functionality covered by the Apache License 2 (APL2) and enterprise functionality covered by the CockroachDB Community License (CCL). To build a pure open-source (APL2) version excluding enterprise functionality, use <code>make buildoss</code>. See this <a href="https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/">blog post</a> for more details.{{site.data.alerts.end}}
+      {{site.data.alerts.callout_info}}기본 실행파일에는 아파치 라이센스 2(APL2)인 코어 오픈소스 기능과 칵로치디비 커뮤니티 라이센스(CCL) 라이센스인 엔터프라이즈 기능이 포함되어 있습니다. 순수 오픈소스(APL2) 버전을 엔터프라이즈 기능없이 빌드하려면 <code>make buildoss</code>를 사용하십시오. 이 <a href="https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/">블로그 포스트</a>에서 세부내용을 확인할 수 있습니다.{{site.data.alerts.end}}
     </li>
     <li>
 
-    <p>Install the <code>cockroach</code> binary into <code>/usr/local/bin</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any directory:</p>
+    <p><code>cockroach</code> 실행파일을 <code>/usr/local/bin</code>에 설치해 <a href="cockroach-commands.html">칵로치 명령어</a>를 어떤 디렉토리에서든 쉾게 실행할 수 있게 하십시오:</p>
 
     {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>make install</code></pre></div>
-    <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
+    <p>권한 에러가 발생한다면 <code>sudo</code> 접두어를 사용하십시오.</p>
 
-    <p>You can also execute the <code>cockroach</code> binary directly from its built location, <code>./src/github.com/cockroachdb/cockroach/cockroach</code>, but the rest of the documentation assumes you have the binary on your <code>PATH</code>.</p>
+    <p>당신은 빌드된 디렉토리에서 <code>cockroach</code> 실행파일을 실행할 수도 있지만, <code>./src/github.com/cockroachdb/cockroach/cockroach</code>, 이어지는 문서는 실행파일이 <code>PATH</code>에 있다고 가정합니다.</p>
     </li>
     <li>
-        <p>Keep up-to-date with CockroachDB releases and best practices:</p>
+        <p>칵로치 디비 릴리즈와 모범사례를 최신으로 유지하십시오:</p>
         <div class="hubspot-install-form install-form-6 clearfix">
           <script>
             hbspt.forms.create({
@@ -194,7 +194,7 @@ key: install-cockroachdb.html
   </ol>
 </div>
 
-<h2 id="whats-next">What&#39;s next?</h2>
+<h2 id="whats-next">무엇을 더 알아볼까요?</h2>
 
 {% include {{ page.version.version }}/misc/install-next-steps.html %}
 


### PR DESCRIPTION
install-cockroachdb-linux.html v19.1/ko를 번역했습니다.
이슈: https://github.com/hueypark/docs/issues/1