### PR TITLE
칵로치 => 카크로치

### DIFF
--- a/l10n/ko/CONTRIBUTING.md
+++ b/l10n/ko/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# 칵로치디비 문서 한글화에 기여하는 방법
+# 카크로치디비 문서 한글화에 기여하는 방법
 
 - 이 문서는 작업 중에 있습니다. 좋은 아이디어가 있다면 이슈나 PR을 만들어 주십시오.
-- 이 저장소는 [칵로치디비 문서 한글화 이슈](https://github.com/cockroachdb/docs/issues/4053)를 해결하기 위해 만들어졌습니다.
+- 이 저장소는 [카크로치디비 문서 한글화 이슈](https://github.com/cockroachdb/docs/issues/4053)를 해결하기 위해 만들어졌습니다.
 
 ## 준비
 
-1. 먼저 칵로치디비에 [기여하는 방법](https://github.com/hueypark/docs/blob/master/CONTRIBUTING.md)을 확인해 로컬에서 문서를 확인해 주십시오.
+1. 먼저 카크로치디비에 [기여하는 방법](https://github.com/hueypark/docs/blob/master/CONTRIBUTING.md)을 확인해 로컬에서 문서를 확인해 주십시오.
 
 ## 번역
 

--- a/l10n/ko/GLOSSARY.md
+++ b/l10n/ko/GLOSSARY.md
@@ -4,8 +4,8 @@
 | archive | 아카이브 | |
 | best practices | 모범사례 | |
 | cluster | 클러스터 | |
-| CockroachDB | 칵로치디비 | |
-| core | 코어 | 칵로치디비 오픈소스 코어를 말하는 경우 |
+| CockroachDB | 카크로치디비 | |
+| core | 코어 | 카크로치디비 오픈소스 코어를 말하는 경우 |
 | daemon | 데몬 | 서버 프로세스를 말하는 경우 |
 | Docker | 도커 | |
 | Docker Hub | 도커 허브 | |


### PR DESCRIPTION
# `칵로치디비`를  `카크로치디비`로 변경.
미국식 발음인 `[kάkròuʧ](카크로치)`와 영국식 발음인 `[kɔ́kròuʧ](코크로치)` 중
소프트웨어 엔지니어링쪽은 미국식 영어를 선호 하므로 미국식 채택.

# 참고
[발음듣기 (British pronunciation과 American pronunciation 선택이 가능할 경우 American 선택)](https://www.google.co.kr/search?q=how+to+pronounce+cockroach&oq=how+to+pronounce+cockroach&ie=UTF-8)